### PR TITLE
Fix an intermittent failure to open the datepicker

### DIFF
--- a/lib/bootstrap_datepicker_spec.rb
+++ b/lib/bootstrap_datepicker_spec.rb
@@ -52,7 +52,7 @@ module BootstrapDatepickerSpec
           and not(contains(concat(' ', @class, ' '), ' new '))
           and normalize-space(text())='#{value.day}']
       eos
-      picker_days.find(:xpath, day_xpath).trigger :click
+      picker_days.find(:xpath, day_xpath).click
 
       # fail unless page.has_no_css? '.datepicker'
     end


### PR DESCRIPTION
In scenarios where I repeatedly set dates for the same datepicker, repeated tries fail to open the dialog unless the clicking on the day is an actual click rather than just triggering "click."
