### PR TITLE
Do a better job finding the datepicker

### DIFF
--- a/lib/bootstrap_datepicker_spec.rb
+++ b/lib/bootstrap_datepicker_spec.rb
@@ -21,7 +21,9 @@ module BootstrapDatepickerSpec
       page = @node.send(:session)
 
       # bootstrap-datepicker appends the container to the end of the body tag
-      picker = page.all('body .datepicker').last
+      picker = page.within(:xpath, "//body") do # break out of any `within`
+        page.all('body > div.datepicker').last
+      end
 
       picker_years = picker.find('.datepicker-years', visible: false)
       picker_months = picker.find('.datepicker-months', visible: false)


### PR DESCRIPTION
If the `BootstrapDatepickerSpec::DatePicker` was instantiated from inside a `within` block, finding the datepicker would not work because it could not be found in the page's current scope. Adding our own temporary `within` block can break out of the current scope and again look in the entire document.

This also scopes the datepicker find to `div`s that are direct children of the body, to help avoid any confusion with other elements with the datepicker class (like inputs).
